### PR TITLE
guids sent in jvm byte order

### DIFF
--- a/src/clr/org/fressian/impl/Fns.cs
+++ b/src/clr/org/fressian/impl/Fns.cs
@@ -44,12 +44,28 @@ namespace org.fressian.impl
 
         public static byte[] UUIDtoByteArray(Guid uuid)
         {
-            return uuid.ToByteArray();
+            return ToOrFromJvmUuidByteOrder( uuid.ToByteArray() );
+        }
+
+        private static byte[] ToOrFromJvmUuidByteOrder( byte[] guidBytes ) {
+            var resultBytes = new byte[ guidBytes.Length ];
+            resultBytes[ 0 ] = guidBytes[ 3 ];
+            resultBytes[ 1 ] = guidBytes[ 2 ];
+            resultBytes[ 2 ] = guidBytes[ 1 ];
+            resultBytes[ 3 ] = guidBytes[ 0 ];
+            resultBytes[ 4 ] = guidBytes[ 5 ];
+            resultBytes[ 5 ] = guidBytes[ 4 ];
+            resultBytes[ 6 ] = guidBytes[ 7 ];
+            resultBytes[ 7 ] = guidBytes[ 6 ];
+            for ( int i = 8 ; i < 16 ; i++ ) {
+                resultBytes[ i ] = guidBytes[ i ];
+            }
+            return resultBytes;
         }
 
         public static Guid byteArrayToUUID(byte[] bytes)
         {
-            return new Guid(bytes);
+            return new Guid( ToOrFromJvmUuidByteOrder( bytes ) );
         }
 
         public static K soloKey<K, V>(IDictionary<K, V> m)


### PR DESCRIPTION
We have used fressian-clr cross platform with jvm implementation. We noticed that ToByteArray method in clr Guid class gives the bytes in different order than jvm. This commit makes fressian-clr Guid compatible with jvm UUID.

This is documented in the Guid Structure, see https://msdn.microsoft.com/en-us/library/system.guid.tobytearray(v=vs.110).aspx

In the Remark section:
"Note that the order of bytes in the returned byte array is different from the string representation of a Guid value. The order of the beginning four-byte group and the next two two-byte groups is reversed, whereas the order of the last two-byte group and the closing six-byte group is the same. "

Best Regards,
Heikki Sutinen
